### PR TITLE
adding the GET /api endpoint that returns all current endpoints 

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -19,4 +19,15 @@ describe("/api/topic", () => {
             });
         })
     })
+    describe("/api", () => {
+        test("Responds with status 200 and serves json file", () => {
+            return request(app)
+            .get("/api")
+            .expect(200)
+            .then(({ body: data })=>{
+                    expect(Object.keys(data).length).not.toBe(0);
+                    expect(typeof data).toBe('object');
+                           });
+            })
+        })    
 })

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
-const {getTopics} = require("./controllers/api.controller")
+const {getTopics, endpoints} = require("./controllers/api.controller")
 
 app.get('/api/topics', getTopics)
+app.get('/api', endpoints)
 module.exports = app;

--- a/controllers/api.controller.js
+++ b/controllers/api.controller.js
@@ -1,8 +1,14 @@
-const {selectTopics} = require("../models/api.model")
+const { end } = require("../db/connection");
+const {selectTopics,serveApi} = require("../models/api.model")
 // const {errorHandlers} = require('../errors')
 
 exports.getTopics = (req, res, next) => {
     selectTopics().then((topics)=>{
         res.status(200).send({topics})
     })
+}
+
+exports.endpoints = (req, res, next) => {
+    const endpoints = require('../endpoints.json'); // require automatically parses
+    res.status(200).json(endpoints)
 }

--- a/models/api.model.js
+++ b/models/api.model.js
@@ -1,8 +1,10 @@
 const db = require("../db/connection");
+const fs = require("fs/promises")
+const endpoints = require('../endpoints.json');
 
 exports.selectTopics = () => {
 return db.query(`SELECT * FROM topics;`).then((result)=>{
-    console.log(result.rows)
+    // console.log(result.rows)
     return result.rows
 })
 }


### PR DESCRIPTION
This should detail endpoints available on /api. At minimum an endpoint should have it's title and a description.